### PR TITLE
Revert to Consumption plan and PS 7.2

### DIFF
--- a/Infrastructure/main.bicep
+++ b/Infrastructure/main.bicep
@@ -191,8 +191,8 @@ resource asp 'Microsoft.Web/serverfarms@2023-12-01' = {
     reserved: true
   }
   sku: {
-    tier: 'FlexConsumption'
-    name: 'FC1'
+    name: 'Y1'
+    tier: 'Consumption'
   }
 }
 
@@ -219,7 +219,7 @@ resource funcApp 'Microsoft.Web/sites@2023-12-01' = {
     serverFarmId: asp.id
     keyVaultReferenceIdentity: 'SystemAssigned'
     siteConfig: {
-      linuxFxVersion: 'POWERSHELL|7.4'
+      linuxFxVersion: 'POWERSHELL|7.2'
       appSettings: [
         {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'


### PR DESCRIPTION
According to: https://azure.microsoft.com/en-us/updates/public-preview-powershell-74-support-for-azure-functions/, PowerShell 7.4 is not supported on Linux Consumption / Flex Consumption plans.